### PR TITLE
Starting a context object where we allocate memory and the app works on things.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,13 +1,15 @@
 
-CC=gcc
+CC=cc
 
 default: resist-mini-app.x
 
-resist-mini-app.x: resist-mini-app.o resist-config.o
-	$(CC) resist-mini-app.o resist-config.o -o $@
+RESIST_MINI_APP_OBJ=resist-mini-app.o resist-config.o resist-context.o
+
+resist-mini-app.x: $(RESIST_MINI_APP_OBJ)
+	$(CC) $(RESIST_MINI_APP_OBJ) -o $@
 
 %.o: %.c
-	$(CC) -c $< -o $@
+	$(CC) -O0 -Wall -Werror -c $< -o $@
 
 format: 
 	uncrustify -c uncrustify.cfg --check *.c *.h
@@ -17,4 +19,5 @@ realclean: clean
 
 clean:
 	rm -rf *.o
+	rm -rf *.uncrustify
 

--- a/src/garbage.c
+++ b/src/garbage.c
@@ -36,9 +36,11 @@ void initialize(struct support_t* support,
                 real v_step,
                 num_angles)
 {
+
     initialize_bins(support, min_wl, max_wl, bin_step);
     initialize_radii(support, min_v, max_v, v_step);
     initialize_rays(support, num_angles);
+
 }
 
 void initialize_bins(struct support_t* support,
@@ -46,6 +48,7 @@ void initialize_bins(struct support_t* support,
                      real max_wl,
                      real bin_step)
 {
+
     /* Minimum wavelength in Angstroms should be positive. */
 
     assert(min_wl > 0.0);
@@ -77,6 +80,7 @@ void initialize_bins(struct support_t* support,
     real start = 0.5 * support->min_wl * (1.0 + doppler_factor); /* Hmmm have to cast the literals? */
     for (size_t i = 0; i < support->num_bins; i++)
         support->bins[i] = start * pow(doppler_factor, i);
+
 }
 
 void initialize_radii(struct support_t* support,
@@ -84,6 +88,7 @@ void initialize_radii(struct support_t* support,
                       real max_v,
                       real v_step)
 {
+
     /* Minimum velocity in Mm/s should be non-negative. */
 
     assert(min_v >= 0.0);
@@ -113,6 +118,7 @@ void initialize_radii(struct support_t* support,
 
 //  for(size_t i = 0; i < support->num_radii; i++)
 //      support->radii[i] = support->min_v + i * support->v_step;
+
 }
 
 void initialize_rays(struct support_t* support,

--- a/src/resist-config.c
+++ b/src/resist-config.c
@@ -1,101 +1,74 @@
 
 #include <assert.h>
-#include <stdio.h>
 
 #include "resist-config.h"
 
-void resist_config_init_default(struct resist_config_t **config)
+void resist_config_init_default(struct resist_config_t** cfg)
 {
-    resist_config_init(config, 10.0, 1.0e6, 0.3, 60.0, 0.1, 32);
+    resist_config_init(cfg, 10.0, 1.0e6, 0.3, 60.0, 0.1, 32);
 }
 
-void resist_config_init_json(struct resist_config_t **config)
+void resist_config_init_json(struct resist_config_t** cfg)
 {
     /* TODO */
 }
 
-void
-resist_config_init(struct resist_config_t **config,
-                   real_t wavelength_min,
-                   real_t wavelength_max,
-                   real_t wavelength_step,
-                   real_t velocity_max,
-                   real_t velocity_step,
-                   size_t angle_count)
+void resist_config_init(struct resist_config_t** cfg,
+                        real_t min_wl,
+                        real_t max_wl,
+                        real_t wl_step,
+                        real_t max_vr,
+                        real_t vr_step,
+                        size_t mu_per_vr)
 {
-    *config =
-        (struct resist_config_t *)malloc(sizeof(struct resist_config_t));
-
-    _resist_config_init_wavelength_params(*config,
-                                          wavelength_min, wavelength_max,
-                                          wavelength_step);
-
-    _resist_config_init_velocity_params(*config, velocity_max,
-                                        velocity_step);
-
-    _resist_config_init_angle_params(*config, angle_count);
+    *cfg = (struct resist_config_t *)malloc(sizeof(struct resist_config_t));
+    _resist_config_init(*cfg, min_wl, max_wl, wl_step, max_vr, vr_step,
+                        mu_per_vr);
 }
 
-void resist_config_finalize(struct resist_config_t *config)
+void resist_config_free(struct resist_config_t* cfg)
 {
-    free(config);
-    config = NULL;
+    free(cfg);
+    cfg = NULL;
 }
 
-void resist_config_output(struct resist_config_t *config)
+void _resist_config_init(struct resist_config_t* cfg,
+                         real_t min_wl,
+                         real_t max_wl,
+                         real_t wl_step,
+                         real_t max_vr,
+                         real_t vr_step,
+                         size_t mu_per_vr)
 {
-    /* TODO Make this a char buffer formatted with snprintf instead. */
-    /* TODO Or do we bother with logging */
-    printf("resist config\n");
-    printf("    wavelength min=%f max=%f step=%f\n",
-           config->wavelength_min, config->wavelength_max,
-           config->wavelength_step);
-    printf("    velocity   max=%f step=%f\n", config->velocity_max,
-           config->velocity_step);
-    printf("    angle      count=%zu\n", config->angle_count);
-}
 
-void _resist_config_init_wavelength_params(struct resist_config_t *config,
-                                           real_t wavelength_min,
-                                           real_t wavelength_max,
-                                           real_t wavelength_step)
-{
     /* Bluest wavelength line loaded should be positive. */
 
-    assert(wavelength_min > 0.0);
-    config->wavelength_min = wavelength_min;
+    assert(min_wl > 0.0);
+    cfg->min_wl = min_wl;
 
     /* Reddest wavelength line loaded should be greater than bluest. */
 
-    assert(wavelength_max > config->wavelength_min);
-    config->wavelength_max = wavelength_max;
+    assert(max_wl > cfg->min_wl);
+    cfg->max_wl = max_wl;
 
     /* Wavelength bin width should be positive. */
 
-    assert(wavelength_step > 0.0);
-    config->wavelength_step = wavelength_step;
-}
+    assert(wl_step > 0.0);
+    cfg->wl_step = wl_step;
 
-void _resist_config_init_velocity_params(struct resist_config_t *config,
-                                         real_t velocity_max,
-                                         real_t velocity_step)
-{
     /* Fastest ejecta velocity should be positive. */
 
-    assert(velocity_max > 0.0);
-    config->velocity_max = velocity_max;
+    assert(max_vr > 0.0);
+    cfg->max_vr = max_vr;
 
     /* Ejecta velocity grid step should be positive. */
 
-    assert(velocity_step > 0.0);
-    config->velocity_step = velocity_step;
-}
+    assert(vr_step > 0.0);
+    cfg->vr_step = vr_step;
 
-void _resist_config_init_angle_params(struct resist_config_t *config,
-                                      real_t angle_count)
-{
     /* Angles per ejecta velocity grid point should be positive. */
 
-    assert(angle_count > 0);
-    config->angle_count = angle_count;
+    assert(mu_per_vr > 0);
+    cfg->mu_per_vr = mu_per_vr;
+
 }

--- a/src/resist-config.h
+++ b/src/resist-config.h
@@ -1,4 +1,7 @@
 
+#ifndef RESIST_CONFIG_H
+#define RESIST_CONFIG_H
+
 #include <stdlib.h>
 
 #include "resist-types.h"
@@ -6,56 +9,48 @@
 /* Application configuration type. */
 
 struct resist_config_t {
-    real_t wavelength_min;  /* Bluest wavelength line loaded, AA.           */
-    real_t wavelength_max;  /* Reddest wavelength line loaded, AA.          */
-    real_t wavelength_step; /* Wavelength bin width, Mm/s.                  */
 
-    real_t velocity_max;    /* Fastest ejecta velocity considered, Mm/s.    */
-    real_t velocity_step;   /* Ejecta velocity grid step, Mm/s.             */
+    real_t min_wl;      /* Bluest wavelength line loaded, AA.           */
+    real_t max_wl;      /* Reddest wavelength line loaded, AA.          */
+    real_t wl_step;     /* Wavelength bin width, Mm/s.                  */
 
-    size_t angle_count;     /* Angles per ejecta velocity grid point.       */
+    real_t max_vr;      /* Fastest ejecta velocity considered, Mm/s.    */
+    real_t vr_step;     /* Ejecta velocity grid step, Mm/s.             */
+
+    size_t mu_per_vr;   /* Angles per ejecta velocity grid point.       */
+
 };
 
 /* Use sensible values to initialize app configuration. */
 
-void resist_config_init_default(struct resist_config_t** config);
+void resist_config_init_default(struct resist_config_t** cfg);
 
 /* Parse JSON object to initialize app configuration. */
 
-void resist_config_init_json(struct resist_config_t** config);
+void resist_config_init_json(struct resist_config_t** cfg);
 
-/* Pass parameters to initialize app configuration. */
+/* Allocate app config, validate and assign parameters to it. */
 
-void resist_config_init(struct resist_config_t** config,
-                        real_t wavelength_min,
-                        real_t wavelength_max,
-                        real_t wavelength_step,
-                        real_t velocity_max,
-                        real_t velocity_step,
-                        size_t angle_count);
+void resist_config_init(struct resist_config_t** cfg,
+                        real_t min_wl,
+                        real_t max_wl,
+                        real_t wl_step,
+                        real_t max_vr,
+                        real_t vr_step,
+                        size_t mu_per_vr);
 
-/* Tear down app configuration. */
+/* Tear down app configuration object. */
 
-void resist_config_finalize(struct resist_config_t* config);
+void resist_config_free(struct resist_config_t* cfg);
 
-/* TODO: This should return snprintf'ed report or decide on logging. */
+/* Validate and assign parameters to an allocated app config. */
 
-void resist_config_output(struct resist_config_t* config);
+void _resist_config_init(struct resist_config_t* cfg,
+                         real_t min_wl,
+                         real_t max_wl,
+                         real_t wl_step,
+                         real_t max_vr,
+                         real_t vr_step,
+                         size_t mu_per_vr);
 
-/* Wavelength bin parameter initialization. */
-
-void _resist_config_init_wavelength_params(struct resist_config_t* config,
-                                           real_t wavelength_min,
-                                           real_t wavelength_max,
-                                           real_t wavelength_step);
-
-/* Ejecta velocity parameter initialization. */
-
-void _resist_config_init_velocity_params(struct resist_config_t* config,
-                                         real_t velocity_max,
-                                         real_t velocity_step);
-
-/* Source function specific intensity angle parameter initialization. */
-
-void _resist_config_init_angle_params(struct resist_config_t* config,
-                                      real_t angle_count);
+#endif /* RESIST_CONFIG_H */

--- a/src/resist-constants.h
+++ b/src/resist-constants.h
@@ -1,6 +1,11 @@
 
+#ifndef RESIST_CONSTANTS_H
+#define RESIST_CONSTANTS_H
+
 #include "resist-types.h"
 
 /* Ultimate speed of your frame and mine, in Mm/s. */
 
-#define c_Mms (real) 299.792458
+#define c_Mms (real_t)299.792458
+
+#endif /* RESIST_CONSTANTS_H */

--- a/src/resist-context.c
+++ b/src/resist-context.c
@@ -1,0 +1,105 @@
+
+#include <assert.h>
+#include <stdio.h>
+#include <tgmath.h>
+
+#include "resist-config.h"
+#include "resist-constants.h"
+#include "resist-context.h"
+
+void resist_context_init(struct resist_context_t** ctx,
+                         struct resist_config_t* cfg)
+{
+    *ctx = (struct resist_context_t*)malloc(sizeof(struct resist_context_t));
+    _resist_context_init(*ctx, cfg);
+}
+
+void resist_context_free(struct resist_context_t* ctx)
+{
+
+    free(ctx->mu);
+    ctx->mu = NULL;
+
+    free(ctx->vr);
+    ctx->vr = NULL;
+
+    free(ctx->wl);
+    ctx->wl = NULL;
+
+    free(ctx);
+    ctx = NULL;
+
+}
+
+void resist_context_output(struct resist_context_t* ctx)
+{
+
+    /* TODO Make this a char buffer formatted with snprintf instead. */
+    /* TODO Or do we bother with logging */
+    printf("resist context\n");
+    printf("    min_wl    = %f  max_wl  = %f  wl_step = %f\n", ctx->min_wl,
+           ctx->max_wl, ctx->wl_step);
+    printf("    max_vr    = %f  vr_step = %f\n", ctx->max_vr, ctx->vr_step);
+    printf("    mu_per_vr = %zu\n", ctx->mu_per_vr);
+    printf("    wl_count  = %zu\n", ctx->wl_count);
+    printf("    vr_count  = %zu\n", ctx->vr_count);
+    printf("    mu_count  = %zu\n", ctx->mu_count);
+
+}
+
+void _resist_context_init(struct resist_context_t* ctx,
+                          struct resist_config_t* cfg)
+{
+
+    /* Copy wavelength parameters from config directly. */
+
+    ctx->min_wl = cfg->min_wl;
+    ctx->max_wl = cfg->max_wl;
+    ctx->wl_step = cfg->wl_step;
+
+    /* Compute number of bins based on wavelength parameters. */
+
+    real_t doppler_factor = 1.0 + ctx->wl_step / c_Mms; /* precision on 1.0 */
+    ctx->wl_count = (size_t)(log(ctx->max_wl / ctx->min_wl) /
+                             log(doppler_factor));
+
+    /* Allocate wavelength bins. */
+
+    ctx->wl = (real_t*)malloc(ctx->wl_count * sizeof(real_t));
+    assert(ctx->wl != NULL);
+
+    /* Assign wavelengths to bins. */
+
+    ctx->wl[0] = ctx->min_wl;
+    for (size_t i = 1; i < ctx->wl_count; i++) {
+        ctx->wl[i] = ctx->wl[i - 1] * doppler_factor;
+    }
+
+    /* Copy velocity parameters from config directly. */
+
+    ctx->max_vr = cfg->max_vr;
+    ctx->vr_step = cfg->vr_step;
+
+    /* Compute number of radii based on velocity parameters. */
+
+    ctx->vr_count = (size_t)(ctx->max_vr / ctx->vr_step) + 1;
+
+    /* Allocate velocity radii but defer definition. */
+
+    ctx->vr = (real_t*)malloc(ctx->vr_count * sizeof(real_t));
+    assert(ctx->vr != NULL);
+
+    /* Copy angle parameters from config directly. */
+
+    ctx->mu_per_vr = cfg->mu_per_vr;
+
+    /* Compute number of angles based on angle parameters and radii. */
+
+    ctx->mu_count = ctx->mu_per_vr * ctx->vr_count;
+
+    /* Allocate angle but defer definition. */
+
+    ctx->mu = (real_t*)malloc(ctx->mu_count * sizeof(real_t));
+    assert(ctx->mu != NULL);
+
+}

--- a/src/resist-context.h
+++ b/src/resist-context.h
@@ -1,0 +1,50 @@
+
+#ifndef RESIST_CONTEXT_H
+#define RESIST_CONTEXT_H
+
+#include "resist-config.h"
+#include "resist-types.h"
+
+/* Application context type. */
+
+struct resist_context_t {
+
+    real_t min_wl;          /* Bluest wavelength line loaded, AA.           */
+    real_t max_wl;          /* Reddest wavelength line loaded, AA.          */
+    real_t wl_step;         /* Wavelength bin width, Mm/s.                  */
+
+    size_t wl_count;
+    real_t* wl;
+
+    real_t max_vr;          /* Fastest ejecta velocity considered, Mm/s.    */
+    real_t vr_step;         /* Ejecta velocity grid step, Mm/s.             */
+
+    size_t vr_count;
+    real_t* vr;
+
+    size_t mu_per_vr;       /* Angles per ejecta velocity grid point.       */
+
+    size_t mu_count;
+    real_t* mu;
+
+};
+
+/* Allocate and initialize app context from config. */
+
+void resist_context_init(struct resist_context_t** ctx,
+                         struct resist_config_t* cfg);
+
+/* Tear down context. */
+
+void resist_context_free(struct resist_context_t* ctx);
+
+/* TODO: This should return snprintf'ed report or decide on logging. */
+
+void resist_context_output(struct resist_context_t* ctx);
+
+/* Validate and initialize an allocated app context. */
+
+void _resist_context_init(struct resist_context_t* ctx,
+                          struct resist_config_t* cfg);
+
+#endif /* RESIST_CONTEXT_H */

--- a/src/resist-memory.h
+++ b/src/resist-memory.h
@@ -1,2 +1,7 @@
 
+#ifndef RESIST_MEMORY_H
+#define RESIST_MEMORY_H
+
 /* Place awesome macro here and replace all the mallocs (and free's?). */
+
+#endif /* RESIST_MEMORY_H */

--- a/src/resist-mini-app.c
+++ b/src/resist-mini-app.c
@@ -1,5 +1,8 @@
 
+#include <unistd.h>
+
 #include "resist-config.h"
+#include "resist-context.h"
 
 int resist_mini_app(int argc,
                     char* argv[]);
@@ -7,17 +10,33 @@ int resist_mini_app(int argc,
 int main(int argc,
          char* argv[])
 {
+
     return resist_mini_app(argc, argv);
+
 }
 
 int resist_mini_app(int argc,
                     char* argv[])
 {
+
     struct resist_config_t* config;
+    struct resist_context_t* context;
+
+    /* Application configuration. */
 
     resist_config_init_default(&config);
-    resist_config_output(config);
-    resist_config_finalize(config);
+
+    /* Context initialization with configuration. */
+
+    resist_context_init(&context, config);
+    resist_config_free(config);
+
+    resist_context_output(context);
+
+    /* Tear-down. */
+
+    resist_context_free(context);
 
     return 0;
+
 }

--- a/src/resist-types.h
+++ b/src/resist-types.h
@@ -1,4 +1,9 @@
 
+#ifndef RESIST_TYPES_H
+#define RESIST_TYPES_H
+
 /* Real type, could be set by a compile time parameter. */
 
 #define real_t double
+
+#endif /* RESIST_TYPES_H */

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -1138,7 +1138,7 @@ nl_class_init_args                        = ignore   # ignore/add/remove/force
 nl_constr_init_args                       = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a function definition
-nl_func_type_name                         = ignore   # ignore/add/remove/force
+nl_func_type_name                         = remove   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name inside a class {}
 # Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
@@ -1149,7 +1149,7 @@ nl_func_type_name_class                   = ignore   # ignore/add/remove/force
 nl_func_scope_name                        = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a prototype
-nl_func_proto_type_name                   = ignore   # ignore/add/remove/force
+nl_func_proto_type_name                   = remove   # ignore/add/remove/force
 
 # Add or remove newline between a function name and the opening '('
 nl_func_paren                             = ignore   # ignore/add/remove/force
@@ -1244,7 +1244,7 @@ nl_brace_struct_var                       = ignore   # ignore/add/remove/force
 nl_define_macro                           = false    # false/true
 
 # Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'
-nl_squeeze_ifdef                          = true    # false/true
+nl_squeeze_ifdef                          = false    # false/true
 
 # Add or remove blank line before 'if'
 nl_before_if                              = ignore   # ignore/add/remove/force
@@ -1426,10 +1426,10 @@ nl_between_get_set                        = 0        # number
 nl_property_brace                         = ignore   # ignore/add/remove/force
 
 # Whether to remove blank lines after '{'
-eat_blanks_after_open_brace               = true    # false/true
+eat_blanks_after_open_brace               = false    # false/true
 
 # Whether to remove blank lines before '}'
-eat_blanks_before_close_brace             = true    # false/true
+eat_blanks_before_close_brace             = false    # false/true
 
 # How aggressively to remove extra newlines not in preproc.
 # 0: No change


### PR DESCRIPTION
This PR starts a context object for the app.

* Include guards.
* Enforce removal of newlines after return type and function decl and def.  Deviation from KR: I think blank lines after opening brace and before closing brace in function definition is okay.
* Allowing space before ifdef esp for end include guard, another K&R deviation apparently.
* Taking out the garbage.c
* Using clang here, added context objects and -W flags.  Any uncrustify stuff also should be cleaned up.
* Moved single-use init functions into the main init part, removed the output bit since this type just holds some data for a little bit.  Also shortened variable names since we are being 80 columns.
* Type typo.
* Now has context in it.
* App context, where things are allocated and live mostly, and objects are worked on by the app.