### PR TITLE
Add memory functions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ CC=cc
 
 default: resist-mini-app.x
 
-RESIST_MINI_APP_OBJ=resist-mini-app.o resist-config.o resist-context.o
+RESIST_MINI_APP_OBJ=resist-mini-app.o resist-config.o resist-context.o resist-memory.o
 
 ifeq ($(USE_HBM),TRUE)
   LDFLAGS=-dynamic -lmemkind

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,11 +5,13 @@ default: resist-mini-app.x
 
 RESIST_MINI_APP_OBJ=resist-mini-app.o resist-config.o resist-context.o
 
+CFLAGS+=-O0 -Wall -Werror
+
 resist-mini-app.x: $(RESIST_MINI_APP_OBJ)
 	$(CC) $(RESIST_MINI_APP_OBJ) -o $@
 
 %.o: %.c
-	$(CC) -O0 -Wall -Werror -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 format: 
 	uncrustify -c uncrustify.cfg --check *.c *.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,9 @@ endif
 
 CFLAGS+=-O0 -Wall -Werror
 
+# Resist uses a number of C99 features.
+CFLAGS+=-std=c99
+
 resist-mini-app.x: $(RESIST_MINI_APP_OBJ)
 	$(CC) $(RESIST_MINI_APP_OBJ) -o $@ $(LDFLAGS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,9 @@
+# To use high-bandwidth memory on Cori at NERSC (2nd-gen Intel Xeon Phi,
+# "Knights Landing"), one needs to load the "memkind" module, and also one must
+# link dynamically. If you try to link statically with memkind you will get
+# lots of errors.
+
+USE_HBM=TRUE
 
 CC=cc
 
@@ -5,10 +11,15 @@ default: resist-mini-app.x
 
 RESIST_MINI_APP_OBJ=resist-mini-app.o resist-config.o resist-context.o
 
+ifeq ($(USE_HBM),TRUE)
+  LDFLAGS=-dynamic -lmemkind
+  CFLAGS=-DUSE_HBM=TRUE
+endif
+
 CFLAGS+=-O0 -Wall -Werror
 
 resist-mini-app.x: $(RESIST_MINI_APP_OBJ)
-	$(CC) $(RESIST_MINI_APP_OBJ) -o $@
+	$(CC) $(RESIST_MINI_APP_OBJ) -o $@ $(LDFLAGS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/src/resist-memory.c
+++ b/src/resist-memory.c
@@ -1,0 +1,48 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef USE_HBM
+#include <hbwmalloc.h>
+#endif
+
+// Wrapper which allocates "regular" or high-bandwidth memory, depending on
+// what is available on the system. Allocating HBM requires the "memkind"
+// library. This wrapper also aligns memory to cache line boundaries. On x86 a
+// cache line is 64 bytes; as there is no way to determine this value at run
+// time, we define it in a macro. We should put this parameter into the
+// Makefile.
+
+#define CACHE_LINE_SIZE 64
+
+void* resist_malloc(size_t n)
+{
+
+    const size_t padded_size = n + CACHE_LINE_SIZE;
+    void* p;
+
+#ifdef USE_HBM
+    p = hbw_malloc(padded_size);
+#else
+    p = malloc(padded_size);
+#endif
+
+    assert(p);
+
+    // Align the memory to the cache line boundary.
+    while ((uintptr_t)p & (uintptr_t)(CACHE_LINE_SIZE - 1)) p++;
+
+    return p;
+}
+
+void resist_free(void* p)
+{
+
+#ifdef USE_HBM
+    hbw_free(p);
+#else
+    free(p);
+#endif
+
+}

--- a/src/resist-memory.h
+++ b/src/resist-memory.h
@@ -2,6 +2,7 @@
 #ifndef RESIST_MEMORY_H
 #define RESIST_MEMORY_H
 
-/* Place awesome macro here and replace all the mallocs (and free's?). */
+void* resist_malloc(size_t n);
+void* resist_free(void* p);
 
 #endif /* RESIST_MEMORY_H */

--- a/src/resist-mini-app.c
+++ b/src/resist-mini-app.c
@@ -3,6 +3,7 @@
 
 #include "resist-config.h"
 #include "resist-context.h"
+#include "resist-memory.h"
 
 int resist_mini_app(int argc,
                     char* argv[]);


### PR DESCRIPTION
This series of commits implements memory allocator/deallocator wrappers. They can call regular `malloc()/free()`, or, if the `memkind` library is available, they can call `hbw_malloc()/hbw_free()` to use high-bandwidth memory. On Cori, one must load the `memkind` module for this to work. These wrappers also align memory to 64-byte boundaries, which correspond to the cache line boundaries on x86.