### PR TITLE
Makefile: disable high-bandwidth-memory by default

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 # link dynamically. If you try to link statically with memkind you will get
 # lots of errors.
 
-USE_HBM=TRUE
+USE_HBM=FALSE
 
 CC=cc
 


### PR DESCRIPTION
Systems with high-bandwidth memory are not common yet, so disable its
usage by default.