### PR TITLE
Modifications enabling ghost grid points

### DIFF
--- a/src/resist-context.c
+++ b/src/resist-context.c
@@ -39,13 +39,14 @@ void resist_context_output(struct resist_context_t* ctx)
     /* TODO Make this a char buffer formatted with snprintf instead. */
     /* TODO Or do we bother with logging */
     printf("resist context\n");
-    printf("    min_wl    = %f  max_wl  = %f  wl_step = %f\n", ctx->min_wl,
-           ctx->max_wl, ctx->wl_step);
-    printf("    max_vr    = %f  vr_step = %f\n", ctx->max_vr, ctx->vr_step);
-    printf("    mu_per_vr = %zu\n", ctx->mu_per_vr);
-    printf("    wl_count  = %zu\n", ctx->wl_count);
-    printf("    vr_count  = %zu\n", ctx->vr_count);
-    printf("    mu_count  = %zu\n", ctx->mu_count);
+    printf("    min_wl    = %10.2e  max_wl  = %10.2e  wl_step = %10f\n",
+           ctx->min_wl, ctx->max_wl, ctx->wl_step);
+    printf("    max_vr    = %10f  vr_step = %10f\n", ctx->max_vr, ctx->vr_step);
+    printf("    mu_per_vr = %10zu\n", ctx->mu_per_vr);
+    printf("    wl_count  = %10zu\n", ctx->wl_count);
+    printf("    vr_count  = %10zu  real_vr_count = %10zu\n", ctx->vr_count,
+           ctx->real_vr_count);
+    printf("    mu_count  = %10zu\n", ctx->mu_count);
 
 }
 
@@ -82,11 +83,22 @@ void _resist_context_init(struct resist_context_t* ctx,
     ctx->max_vr = cfg->max_vr;
     ctx->vr_step = cfg->vr_step;
 
-    /* Compute number of radii based on velocity parameters. */
+    /* Compute number of real velocity grid points based on velocity
+       parameters. */
 
-    ctx->vr_count = (size_t)(ctx->max_vr / ctx->vr_step) + 1;
+    ctx->real_vr_count = (size_t)(ctx->max_vr / ctx->vr_step) + 1;
 
-    /* Allocate velocity radii but defer definition. */
+    /* Ejecta velocity grid includes ghost points outside the line forming
+       region. For now we simply make the entire velocity grid larger by
+       some factor determined by the geometry of the line forming region.
+       The highest velocity grid point needs to be able to couple to a
+       point roughly 2 * max_vr away, or exactly 2 * max_vr if there is no
+       photosphere present. Hence we enlarge the grid by a factor of 3, and
+       the outer 2/3 of all grid points are ghost points. */
+
+    ctx->vr_count = 3 * ctx->real_vr_count;
+
+    /* Allocate velocity grid but defer definition. */
 
     ctx->vr = (real_t*)resist_malloc(ctx->vr_count * sizeof(real_t));
     assert(ctx->vr);
@@ -95,9 +107,10 @@ void _resist_context_init(struct resist_context_t* ctx,
 
     ctx->mu_per_vr = cfg->mu_per_vr;
 
-    /* Compute number of angles based on angle parameters and radii. */
+    /* Compute number of angles based on angle parameters and velocity grid
+       size. We only need to consider angles for real velocity grid points. */
 
-    ctx->mu_count = ctx->mu_per_vr * ctx->vr_count;
+    ctx->mu_count = ctx->mu_per_vr * ctx->real_vr_count;
 
     /* Allocate angle but defer definition. */
 

--- a/src/resist-context.h
+++ b/src/resist-context.h
@@ -13,19 +13,20 @@ struct resist_context_t {
     real_t max_wl;          /* Reddest wavelength line loaded, AA.          */
     real_t wl_step;         /* Wavelength bin width, Mm/s.                  */
 
-    size_t wl_count;
-    real_t* wl;
+    size_t wl_count;        /* Number of wavelength bins.                   */
+    real_t* wl;             /* Wavelength bins, blue edge, AA.              */
 
     real_t max_vr;          /* Fastest ejecta velocity considered, Mm/s.    */
     real_t vr_step;         /* Ejecta velocity grid step, Mm/s.             */
 
-    size_t vr_count;
-    real_t* vr;
+    size_t vr_count;        /* Velocity grid size including ghost cells.    */
+    size_t real_vr_count;   /* Non-ghost cell velocity grid size.           */
+    real_t* vr;             /* Velocity grid, Mm/s.                         */
 
     size_t mu_per_vr;       /* Angles per ejecta velocity grid point.       */
 
-    size_t mu_count;
-    real_t* mu;
+    size_t mu_count;        /* Total number of angles.                      */
+    real_t* mu;             /* Angle grid, cosines.                         */
 
 };
 


### PR DESCRIPTION
The velocity grid allocation is modified so that ghost grid points are
allocated.  The full grid including ghost zones is 3 times the size of
the real grid, based on considerations from the geometry of the line
forming region.  The real grid is of size `real_vr_count` and the full
grid including ghost zones is of size `vr_count`.  So, when iterating
over wavelengths in the `tau` and `src` arrays, the right chunk size is
`vr_count`.

Additionally only real grid cells need to have associated angles for
computing mean intensity.  So we don't make allocations for angles in
the ghost points.

Further specifics:

* Comment struct, add real velocity grid variable
* Comments explain choice of 3 for full grid factor
* Comments explain why angles aren't allocated for ghosts
* Changes to the output format to include real grid size