### PR TITLE
Enhance uncrustify experience

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,8 @@
 # link dynamically. If you try to link statically with memkind you will get
 # lots of errors.
 
+SHELL=/bin/bash
+
 USE_HBM=FALSE
 
 default: resist-mini-app.x
@@ -28,7 +30,12 @@ resist-mini-app.x: $(RESIST_MINI_APP_OBJ)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 format: 
-	uncrustify -c uncrustify.cfg --check *.c *.h
+	@set -o pipefail; uncrustify -c uncrustify.cfg --check *.c *.h 2>&1 \
+        | GREP_COLOR='01;32' egrep --color=always 'PASS|$$' \
+        | GREP_COLORS='01;31' egrep --color=always 'FAIL|$$' \
+
+reformat:
+	uncrustify -c uncrustify.cfg *.c *.h --no-backup --mtime
 
 realclean: clean
 	rm -rf *.x


### PR DESCRIPTION
The `PASS` and `FAIL` messages emitted by `uncrustify` should now be
colored green and red respectively, making it easier to notice that a
formatting error has been committed.  This is a bit of hackery but
hopefully it will work portably (ha).  To make this all work I had to
set the `$SHELL` variable to `/bin/bash`.

An additional target `reformat` has been added that is a scorched-earth
target that reformats all the source files in place but preserves the
modification times.  If nothing is done it should be no change to the
source files.