### PR TITLE
Define basic setup interface

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ USE_HBM=FALSE
 
 default: resist-mini-app.x
 
-RESIST_MINI_APP_OBJ=resist-mini-app.o resist-config.o resist-context.o resist-memory.o
+RESIST_MINI_APP_OBJ=resist-mini-app.o resist-config.o resist-context.o resist-memory.o resist-setup.o
 
 ifeq ($(USE_HBM),TRUE)
   LDFLAGS=-dynamic -lmemkind

--- a/src/resist-setup.c
+++ b/src/resist-setup.c
@@ -1,0 +1,23 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "resist-memory.h"
+#include "resist-setup.h"
+
+void resist_setup_init_default(struct resist_setup_t** stp)
+{
+    resist_setup_init(stp);
+}
+
+void resist_setup_init(struct resist_setup_t** stp)
+{
+    *stp = (struct resist_setup_t *)resist_malloc(
+        sizeof(struct resist_setup_t));
+}
+
+void resist_setup_free(struct resist_setup_t* stp)
+{
+    resist_free(stp);
+    stp = NULL;
+}

--- a/src/resist-setup.h
+++ b/src/resist-setup.h
@@ -1,0 +1,22 @@
+
+#ifndef RESIST_SETUP_H
+#define RESIST_SETUP_H
+
+/* Setup type. */
+
+struct resist_setup_t {
+};
+
+/* Use sensible values to initialize a setup. */
+
+void resist_setup_init_default(struct resist_setup_t** stp);
+
+/* Allocate setup, validate and assign parameters to it. */
+
+void resist_setup_init(struct resist_setup_t** stp);
+
+/* Tear down setup object. */
+
+void resist_setup_free(struct resist_setup_t* stp);
+
+#endif /* RESIST_SETUP_H */


### PR DESCRIPTION
This is the "setup" interface, the input needed for computing a spectrum assuming a given context.  Probably won't start using this for a while.