### PR TITLE
resist-context: remove redundant asserts following memory allocation

### DIFF
--- a/src/resist-context.c
+++ b/src/resist-context.c
@@ -1,5 +1,4 @@
 
-#include <assert.h>
 #include <stdio.h>
 #include <tgmath.h>
 
@@ -75,7 +74,6 @@ void _resist_context_init(struct resist_context_t* ctx,
     /* Allocate wavelength bins. */
 
     ctx->wl = (real_t*)resist_malloc(ctx->wl_count * sizeof(real_t));
-    assert(ctx->wl);
 
     /* Assign wavelengths to bins. */
 
@@ -107,7 +105,6 @@ void _resist_context_init(struct resist_context_t* ctx,
     /* Allocate velocity grid but defer definition. */
 
     ctx->vr = (real_t*)resist_malloc(ctx->vr_count * sizeof(real_t));
-    assert(ctx->vr);
 
     /* Copy angle parameters from config directly. */
 
@@ -121,18 +118,15 @@ void _resist_context_init(struct resist_context_t* ctx,
     /* Allocate angle but defer definition. */
 
     ctx->mu = (real_t*)resist_malloc(ctx->mu_count * sizeof(real_t));
-    assert(ctx->mu);
 
     /* Allocate Sobolev opacity bins, including ghost values. */
 
     ctx->tau = (real_t*)resist_malloc(ctx->wl_count * ctx->vr_count *
                                       sizeof(real_t));
-    assert(ctx->tau);
 
     /* Allocate source function values, including ghost values. */
 
     ctx->src = (real_t*)resist_malloc(ctx->wl_count * ctx->vr_count *
                                       sizeof(real_t));
-    assert(ctx->src);
 
 }


### PR DESCRIPTION
We already have an assert in resist_malloc() that verifies that the
allocation succeeded, so we do not need another one here.