### PR TITLE
resist-memory: set pointer to NULL after free() in resist_free()

### DIFF
--- a/src/resist-config.c
+++ b/src/resist-config.c
@@ -31,7 +31,6 @@ void resist_config_init(struct resist_config_t** cfg,
 void resist_config_free(struct resist_config_t* cfg)
 {
     resist_free(cfg);
-    cfg = NULL;
 }
 
 void _resist_config_init(struct resist_config_t* cfg,

--- a/src/resist-context.c
+++ b/src/resist-context.c
@@ -19,25 +19,18 @@ void resist_context_free(struct resist_context_t* ctx)
 {
 
     resist_free(ctx->src);
-    ctx->src = NULL;
 
     resist_free(ctx->tau);
-    ctx->tau = NULL;
 
     resist_free(ctx->in);
-    ctx->in = NULL;
 
     resist_free(ctx->mu);
-    ctx->mu = NULL;
 
     resist_free(ctx->vr);
-    ctx->vr = NULL;
 
     resist_free(ctx->wl);
-    ctx->wl = NULL;
 
     resist_free(ctx);
-    ctx = NULL;
 
 }
 

--- a/src/resist-memory.c
+++ b/src/resist-memory.c
@@ -49,4 +49,5 @@ void resist_free(void* p)
     free(*((void**)p - 1));
 #endif
 
+    p = NULL;
 }

--- a/src/resist-setup.c
+++ b/src/resist-setup.c
@@ -19,5 +19,4 @@ void resist_setup_init(struct resist_setup_t** stp)
 void resist_setup_free(struct resist_setup_t* stp)
 {
     resist_free(stp);
-    stp = NULL;
 }


### PR DESCRIPTION
This addresses #37.