### PR TITLE
Redefine and clarify wavelength parameters

### DIFF
--- a/src/resist-config.c
+++ b/src/resist-config.c
@@ -6,7 +6,7 @@
 
 void resist_config_init_default(struct resist_config_t** cfg)
 {
-    resist_config_init(cfg, 10.0, 1.0e6, 0.3, 60.0, 0.1, 32);
+    resist_config_init(cfg, 3000.0, 10000.0, 10.0, 0.3, 60.0, 0.1, 32);
 }
 
 void resist_config_init_json(struct resist_config_t** cfg)
@@ -15,17 +15,18 @@ void resist_config_init_json(struct resist_config_t** cfg)
 }
 
 void resist_config_init(struct resist_config_t** cfg,
-                        real_t min_wl,
-                        real_t max_wl,
-                        real_t wl_step,
+                        real_t spec_wl_min,
+                        real_t spec_wl_max,
+                        real_t spec_wl_step,
+                        real_t opac_wl_step,
                         real_t max_vr,
                         real_t vr_step,
                         size_t mu_per_vr)
 {
     *cfg = (struct resist_config_t *)resist_malloc(
         sizeof(struct resist_config_t));
-    _resist_config_init(*cfg, min_wl, max_wl, wl_step, max_vr, vr_step,
-                        mu_per_vr);
+    _resist_config_init(*cfg, spec_wl_min, spec_wl_max, spec_wl_step,
+                        opac_wl_step, max_vr, vr_step, mu_per_vr);
 }
 
 void resist_config_free(struct resist_config_t* cfg)
@@ -34,28 +35,34 @@ void resist_config_free(struct resist_config_t* cfg)
 }
 
 void _resist_config_init(struct resist_config_t* cfg,
-                         real_t min_wl,
-                         real_t max_wl,
-                         real_t wl_step,
+                         real_t spec_wl_min,
+                         real_t spec_wl_max,
+                         real_t spec_wl_step,
+                         real_t opac_wl_step,
                          real_t max_vr,
                          real_t vr_step,
                          size_t mu_per_vr)
 {
 
-    /* Bluest wavelength line loaded should be positive. */
+    /* Bluest spectrum wavelength should be positive. */
 
-    assert(min_wl > 0.0);
-    cfg->min_wl = min_wl;
+    assert(spec_wl_min > 0.0);
+    cfg->spec_wl_min = spec_wl_min;
 
-    /* Reddest wavelength line loaded should be greater than bluest. */
+    /* Reddest spectrum wavelength should be greater than bluest. */
 
-    assert(max_wl > cfg->min_wl);
-    cfg->max_wl = max_wl;
+    assert(spec_wl_max > cfg->spec_wl_min);
+    cfg->spec_wl_max = spec_wl_max;
+
+    /* Default spectrum sampling should be positive. */
+
+    assert(spec_wl_step > 0.0);
+    cfg->spec_wl_step = spec_wl_step;
 
     /* Wavelength bin width should be positive. */
 
-    assert(wl_step > 0.0);
-    cfg->wl_step = wl_step;
+    assert(opac_wl_step > 0.0);
+    cfg->opac_wl_step = opac_wl_step;
 
     /* Fastest ejecta velocity should be positive. */
 

--- a/src/resist-config.h
+++ b/src/resist-config.h
@@ -10,9 +10,11 @@
 
 struct resist_config_t {
 
-    real_t min_wl;      /* Bluest wavelength line loaded, AA.           */
-    real_t max_wl;      /* Reddest wavelength line loaded, AA.          */
-    real_t wl_step;     /* Wavelength bin width, Mm/s.                  */
+    real_t spec_wl_min;     /* Bluest spectrum wavelength, AA.          */
+    real_t spec_wl_max;     /* Reddest spectrum wavelength, AA.         */
+    real_t spec_wl_step;    /* Default spectrum sampling, AA.           */
+
+    real_t opac_wl_step;    /* Opacity bin width, Mm/s.                 */
 
     real_t max_vr;      /* Fastest ejecta velocity considered, Mm/s.    */
     real_t vr_step;     /* Ejecta velocity grid step, Mm/s.             */
@@ -32,9 +34,10 @@ void resist_config_init_json(struct resist_config_t** cfg);
 /* Allocate app config, validate and assign parameters to it. */
 
 void resist_config_init(struct resist_config_t** cfg,
-                        real_t min_wl,
-                        real_t max_wl,
-                        real_t wl_step,
+                        real_t spec_wl_min,
+                        real_t spec_wl_max,
+                        real_t spec_wl_step,
+                        real_t opac_wl_step,
                         real_t max_vr,
                         real_t vr_step,
                         size_t mu_per_vr);
@@ -46,9 +49,10 @@ void resist_config_free(struct resist_config_t* cfg);
 /* Validate and assign parameters to an allocated app config. */
 
 void _resist_config_init(struct resist_config_t* cfg,
-                         real_t min_wl,
-                         real_t max_wl,
-                         real_t wl_step,
+                         real_t spec_wl_min,
+                         real_t spec_wl_max,
+                         real_t spec_wl_step,
+                         real_t opac_wl_step,
                          real_t max_vr,
                          real_t vr_step,
                          size_t mu_per_vr);

--- a/src/resist-context.h
+++ b/src/resist-context.h
@@ -10,9 +10,13 @@
 
 struct resist_context_t {
 
-    real_t min_wl;          /* Bluest wavelength line loaded, AA.           */
-    real_t max_wl;          /* Reddest wavelength line loaded, AA.          */
-    real_t wl_step;         /* Wavelength bin width, Mm/s.                  */
+    real_t spec_wl_min;     /* Bluest spectrum wavelength, AA.              */
+    real_t spec_wl_max;     /* Reddest spectrum wavelength, AA.             */
+    real_t spec_wl_step;    /* Default spectrum sampling, AA.               */
+
+    real_t opac_wl_min;     /* Bluest opacity bin, AA.                      */
+    real_t opac_wl_max;     /* Reddest opacity bin, AA.                     */
+    real_t opac_wl_step;    /* Opacity bin width, Mm/s.                     */
 
     size_t wl_count;        /* Number of wavelength bins.                   */
     real_t* wl;             /* Wavelength bins, blue edge, AA.              */


### PR DESCRIPTION
This commit clarifies that there are two wavelength grids we have to
worry about, one for the eventual output spectrum and one for the
opacity bins.  They have different limits and in fact the former
determines the latter along with the LFR geometry.  To get the source
function kernel right we want to have the logic in that does that and we
ought to clarify the conventions earlier rather than later.  In more
detail what this commit does is:

* Replace `wl` limits in the config with spectrum limits and step
* Define opacity binning, limits from by spectrum limit and `max_vr`
* Update interface to clarify `spec_wl` and `opac_wl` grids
* Modify `config_init_default` to reflect this new interface
* Provide more sensible UVOIR default for `config_init_default`
* Update necessary assertions in `config`
* Define `opac_wl` params in `context` based on `spec_wl` lims, max_vr

This commit should be orthogonal to the one in #39, and once that one is
merged I'll rebase then merge this one.  I'll leave certain other
convention changes about `context` for a future commit.